### PR TITLE
feat(directory): add user CRUD and group management tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,27 @@ The application requires the following environment variables to be set:
 | `GOOGLE_SERVICE_ACCOUNT` | The path to the service account JSON key file |
 | `GOOGLE_ADMIN_EMAIL` | The email address of the Google Workspace admin user to impersonate |
 
+### Transport (optional)
+
+By default the server runs over stdio. Set `MCP_TRANSPORT=http` to serve over the
+Streamable HTTP transport instead.
+
+| Variable | Description |
+|----------|-------------|
+| `MCP_TRANSPORT` | Transport to use: `stdio` (default) or `http` |
+| `MCP_HTTP_ADDR` | Listen address for HTTP transport (default `:8080`) |
+| `MCP_AUTH_TOKEN` | When set, HTTP requests must include `Authorization: Bearer <token>` |
+
+```bash
+MCP_TRANSPORT=http MCP_HTTP_ADDR=:8080 MCP_AUTH_TOKEN=your-secret-token google-workspace-mcp
+```
+
+Clients then connect to `http://<host>:8080/` and send the bearer token, e.g.:
+
+```
+Authorization: Bearer your-secret-token
+```
+
 ## Usage
 
 ### Build
@@ -62,6 +83,19 @@ make build
 ### Directory Tools
 - `directory_users` - List all users in your Google Workspace directory
 - `create_user` - Create a new user in Google Workspace
+- `get_user` - Get detailed information about a specific user
+- `update_user` - Update an existing user's name, password, or organizational unit
+- `delete_user` - Delete a user from Google Workspace
+- `suspend_user` - Suspend or restore a user account
+
+### Group Tools
+- `list_groups` - List groups in a domain
+- `get_group` - Get detailed information about a specific group
+- `create_group` - Create a new group in Google Workspace
+- `delete_group` - Delete a group from Google Workspace
+- `list_group_members` - List members of a group
+- `add_group_member` - Add a member to a group
+- `remove_group_member` - Remove a member from a group
 
 ### Gmail Tools
 - `list_gmail` - List recent Gmail messages (requires Gmail API access)
@@ -99,6 +133,8 @@ make build
 When setting up domain-wide delegation for your service account, ensure you grant the following OAuth scopes:
 
 - `https://www.googleapis.com/auth/admin.directory.user` - For accessing and managing directory user information
+- `https://www.googleapis.com/auth/admin.directory.group` - For managing groups
+- `https://www.googleapis.com/auth/admin.directory.group.member` - For managing group members
 - `https://www.googleapis.com/auth/gmail.readonly` - For reading Gmail messages
 - `https://www.googleapis.com/auth/calendar` - For reading and writing calendar events
 - `https://www.googleapis.com/auth/drive` - For full access to Google Drive (reading, writing, and managing files)

--- a/cmd/google-workspace-mcp/http.go
+++ b/cmd/google-workspace-mcp/http.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"crypto/subtle"
+	"log"
+	"net/http"
+	"os"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// runHTTP serves the MCP server over the Streamable HTTP transport.
+//
+// Configuration (environment variables):
+//   - MCP_HTTP_ADDR:  listen address, defaults to ":8080"
+//   - MCP_AUTH_TOKEN: when set, requests must carry "Authorization: Bearer <token>"
+func runHTTP(server *mcp.Server) error {
+	addr := os.Getenv("MCP_HTTP_ADDR")
+	if addr == "" {
+		addr = ":8080"
+	}
+
+	handler := mcp.NewStreamableHTTPHandler(func(*http.Request) *mcp.Server {
+		return server
+	}, nil)
+
+	var h http.Handler = handler
+	if token := os.Getenv("MCP_AUTH_TOKEN"); token != "" {
+		h = withTokenAuth(h, token)
+		log.Printf("Google Workspace MCP listening on %s (streamable HTTP, bearer auth enabled)", addr)
+	} else {
+		log.Printf("Google Workspace MCP listening on %s (streamable HTTP, no auth)", addr)
+	}
+
+	return http.ListenAndServe(addr, h)
+}
+
+// withTokenAuth wraps next, requiring an "Authorization: Bearer <token>" header
+// that matches token. The comparison is constant-time to avoid leaking the
+// token through response timing.
+func withTokenAuth(next http.Handler, token string) http.Handler {
+	expected := []byte("Bearer " + token)
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got := []byte(r.Header.Get("Authorization"))
+		if subtle.ConstantTimeCompare(got, expected) != 1 {
+			w.Header().Set("WWW-Authenticate", "Bearer")
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}

--- a/cmd/google-workspace-mcp/http_test.go
+++ b/cmd/google-workspace-mcp/http_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestWithTokenAuth(t *testing.T) {
+	const token = "s3cr3t-token"
+
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	handler := withTokenAuth(next, token)
+
+	tests := []struct {
+		name       string
+		authHeader string
+		wantStatus int
+	}{
+		{"valid token", "Bearer " + token, http.StatusOK},
+		{"missing header", "", http.StatusUnauthorized},
+		{"wrong token", "Bearer wrong", http.StatusUnauthorized},
+		{"missing bearer prefix", token, http.StatusUnauthorized},
+		{"wrong scheme", "Basic " + token, http.StatusUnauthorized},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/", nil)
+			if tt.authHeader != "" {
+				req.Header.Set("Authorization", tt.authHeader)
+			}
+			rec := httptest.NewRecorder()
+
+			handler.ServeHTTP(rec, req)
+
+			if rec.Code != tt.wantStatus {
+				t.Errorf("status = %d, want %d", rec.Code, tt.wantStatus)
+			}
+			if tt.wantStatus == http.StatusUnauthorized {
+				if got := rec.Header().Get("WWW-Authenticate"); got != "Bearer" {
+					t.Errorf("WWW-Authenticate = %q, want %q", got, "Bearer")
+				}
+			}
+		})
+	}
+}

--- a/cmd/google-workspace-mcp/main.go
+++ b/cmd/google-workspace-mcp/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"log"
+	"os"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"go.orx.me/mcp/google-workspace/internal/tools"
@@ -16,6 +17,14 @@ func main() {
 
 	// Register all tools
 	tools.RegisterAll(server)
+
+	// Select transport via MCP_TRANSPORT (stdio by default).
+	if os.Getenv("MCP_TRANSPORT") == "http" {
+		if err := runHTTP(server); err != nil {
+			log.Fatal(err)
+		}
+		return
+	}
 
 	// Run server over stdio
 	if err := server.Run(context.Background(), &mcp.StdioTransport{}); err != nil {

--- a/internal/tools/calendar.go
+++ b/internal/tools/calendar.go
@@ -12,26 +12,26 @@ import (
 
 // ListCalendarEventsInput defines input for list_calendar_events tool
 type ListCalendarEventsInput struct {
-	Email string `json:"email" jsonschema:"required,description=Email address to access calendar"`
+	Email string `json:"email" jsonschema:"Email address to access calendar"`
 }
 
 // ListCalendarEventsOutput defines output for list_calendar_events tool
 type ListCalendarEventsOutput struct {
-	Events string `json:"events" jsonschema:"description=List of upcoming events"`
+	Events string `json:"events" jsonschema:"List of upcoming events"`
 }
 
 // CreateCalendarEventInput defines input for create_calendar_event tool
 type CreateCalendarEventInput struct {
-	Email       string `json:"email" jsonschema:"required,description=Email address to access calendar"`
-	Summary     string `json:"summary" jsonschema:"required,description=Event title/summary"`
-	Description string `json:"description,omitempty" jsonschema:"description=Event description"`
-	StartTime   string `json:"startTime" jsonschema:"required,description=Start time in RFC3339 format"`
-	EndTime     string `json:"endTime" jsonschema:"required,description=End time in RFC3339 format"`
+	Email       string `json:"email" jsonschema:"Email address to access calendar"`
+	Summary     string `json:"summary" jsonschema:"Event title/summary"`
+	Description string `json:"description,omitempty" jsonschema:"Event description"`
+	StartTime   string `json:"startTime" jsonschema:"Start time in RFC3339 format"`
+	EndTime     string `json:"endTime" jsonschema:"End time in RFC3339 format"`
 }
 
 // CreateCalendarEventOutput defines output for create_calendar_event tool
 type CreateCalendarEventOutput struct {
-	Result string `json:"result" jsonschema:"description=Result of event creation"`
+	Result string `json:"result" jsonschema:"Result of event creation"`
 }
 
 // ListCalendarEvents handles the list_calendar_events tool call

--- a/internal/tools/directory.go
+++ b/internal/tools/directory.go
@@ -11,70 +11,70 @@ import (
 
 // ListUsersInput defines input for directory_users tool
 type ListUsersInput struct {
-	Domain string `json:"domain" jsonschema:"required,description=Domain to list users from"`
+	Domain string `json:"domain" jsonschema:"Domain to list users from"`
 }
 
 // ListUsersOutput defines output for directory_users tool
 type ListUsersOutput struct {
-	Users string `json:"users" jsonschema:"description=List of users with email and name"`
+	Users string `json:"users" jsonschema:"List of users with email and name"`
 }
 
 // CreateUserInput defines input for create_user tool
 type CreateUserInput struct {
-	Email     string `json:"email" jsonschema:"required,description=Email address for the new user"`
-	FirstName string `json:"firstName" jsonschema:"required,description=First name of the user"`
-	LastName  string `json:"lastName" jsonschema:"required,description=Last name of the user"`
-	Password  string `json:"password" jsonschema:"required,description=Initial password for the user"`
+	Email     string `json:"email" jsonschema:"Email address for the new user"`
+	FirstName string `json:"firstName" jsonschema:"First name of the user"`
+	LastName  string `json:"lastName" jsonschema:"Last name of the user"`
+	Password  string `json:"password" jsonschema:"Initial password for the user"`
 }
 
 // CreateUserOutput defines output for create_user tool
 type CreateUserOutput struct {
-	Result string `json:"result" jsonschema:"description=Result of user creation"`
+	Result string `json:"result" jsonschema:"Result of user creation"`
 }
 
 // GetUserInput defines input for get_user tool
 type GetUserInput struct {
-	UserKey string `json:"userKey" jsonschema:"required,description=User's primary email address or unique user ID"`
+	UserKey string `json:"userKey" jsonschema:"User's primary email address or unique user ID"`
 }
 
 // GetUserOutput defines output for get_user tool
 type GetUserOutput struct {
-	User string `json:"user" jsonschema:"description=Detailed information about the user"`
+	User string `json:"user" jsonschema:"Detailed information about the user"`
 }
 
 // UpdateUserInput defines input for update_user tool
 type UpdateUserInput struct {
-	UserKey   string `json:"userKey" jsonschema:"required,description=User's primary email address or unique user ID"`
-	FirstName string `json:"firstName,omitempty" jsonschema:"description=New first (given) name"`
-	LastName  string `json:"lastName,omitempty" jsonschema:"description=New last (family) name"`
-	Password  string `json:"password,omitempty" jsonschema:"description=New password for the user"`
-	OrgUnit   string `json:"orgUnitPath,omitempty" jsonschema:"description=Organizational unit path to move the user to (e.g. /Sales)"`
+	UserKey   string `json:"userKey" jsonschema:"User's primary email address or unique user ID"`
+	FirstName string `json:"firstName,omitempty" jsonschema:"New first (given) name"`
+	LastName  string `json:"lastName,omitempty" jsonschema:"New last (family) name"`
+	Password  string `json:"password,omitempty" jsonschema:"New password for the user"`
+	OrgUnit   string `json:"orgUnitPath,omitempty" jsonschema:"Organizational unit path to move the user to (e.g. /Sales)"`
 }
 
 // UpdateUserOutput defines output for update_user tool
 type UpdateUserOutput struct {
-	Result string `json:"result" jsonschema:"description=Result of user update"`
+	Result string `json:"result" jsonschema:"Result of user update"`
 }
 
 // DeleteUserInput defines input for delete_user tool
 type DeleteUserInput struct {
-	UserKey string `json:"userKey" jsonschema:"required,description=User's primary email address or unique user ID"`
+	UserKey string `json:"userKey" jsonschema:"User's primary email address or unique user ID"`
 }
 
 // DeleteUserOutput defines output for delete_user tool
 type DeleteUserOutput struct {
-	Result string `json:"result" jsonschema:"description=Result of user deletion"`
+	Result string `json:"result" jsonschema:"Result of user deletion"`
 }
 
 // SuspendUserInput defines input for suspend_user tool
 type SuspendUserInput struct {
-	UserKey   string `json:"userKey" jsonschema:"required,description=User's primary email address or unique user ID"`
-	Suspended bool   `json:"suspended" jsonschema:"required,description=Set true to suspend the account, false to restore it"`
+	UserKey   string `json:"userKey" jsonschema:"User's primary email address or unique user ID"`
+	Suspended bool   `json:"suspended" jsonschema:"Set true to suspend the account, false to restore it"`
 }
 
 // SuspendUserOutput defines output for suspend_user tool
 type SuspendUserOutput struct {
-	Result string `json:"result" jsonschema:"description=Result of suspending or restoring the user"`
+	Result string `json:"result" jsonschema:"Result of suspending or restoring the user"`
 }
 
 // ListUsers handles the directory_users tool call

--- a/internal/tools/directory.go
+++ b/internal/tools/directory.go
@@ -84,14 +84,15 @@ func ListUsers(ctx context.Context, req *mcp.CallToolRequest, input ListUsersInp
 		return nil, ListUsersOutput{}, err
 	}
 
-	users, err := client.Users.List().Domain(input.Domain).Do()
+	var result string
+	err = client.Users.List().Domain(input.Domain).Pages(ctx, func(page *admin.Users) error {
+		for _, user := range page.Users {
+			result += fmt.Sprintf("Email: %s Name: %s\n", user.PrimaryEmail, user.Name.FullName)
+		}
+		return nil
+	})
 	if err != nil {
 		return nil, ListUsersOutput{}, err
-	}
-
-	var result string
-	for _, user := range users.Users {
-		result += fmt.Sprintf("Email: %s Name: %s\n", user.PrimaryEmail, user.Name.FullName)
 	}
 
 	return nil, ListUsersOutput{Users: result}, nil

--- a/internal/tools/directory.go
+++ b/internal/tools/directory.go
@@ -32,6 +32,51 @@ type CreateUserOutput struct {
 	Result string `json:"result" jsonschema:"description=Result of user creation"`
 }
 
+// GetUserInput defines input for get_user tool
+type GetUserInput struct {
+	UserKey string `json:"userKey" jsonschema:"required,description=User's primary email address or unique user ID"`
+}
+
+// GetUserOutput defines output for get_user tool
+type GetUserOutput struct {
+	User string `json:"user" jsonschema:"description=Detailed information about the user"`
+}
+
+// UpdateUserInput defines input for update_user tool
+type UpdateUserInput struct {
+	UserKey   string `json:"userKey" jsonschema:"required,description=User's primary email address or unique user ID"`
+	FirstName string `json:"firstName,omitempty" jsonschema:"description=New first (given) name"`
+	LastName  string `json:"lastName,omitempty" jsonschema:"description=New last (family) name"`
+	Password  string `json:"password,omitempty" jsonschema:"description=New password for the user"`
+	OrgUnit   string `json:"orgUnitPath,omitempty" jsonschema:"description=Organizational unit path to move the user to (e.g. /Sales)"`
+}
+
+// UpdateUserOutput defines output for update_user tool
+type UpdateUserOutput struct {
+	Result string `json:"result" jsonschema:"description=Result of user update"`
+}
+
+// DeleteUserInput defines input for delete_user tool
+type DeleteUserInput struct {
+	UserKey string `json:"userKey" jsonschema:"required,description=User's primary email address or unique user ID"`
+}
+
+// DeleteUserOutput defines output for delete_user tool
+type DeleteUserOutput struct {
+	Result string `json:"result" jsonschema:"description=Result of user deletion"`
+}
+
+// SuspendUserInput defines input for suspend_user tool
+type SuspendUserInput struct {
+	UserKey   string `json:"userKey" jsonschema:"required,description=User's primary email address or unique user ID"`
+	Suspended bool   `json:"suspended" jsonschema:"required,description=Set true to suspend the account, false to restore it"`
+}
+
+// SuspendUserOutput defines output for suspend_user tool
+type SuspendUserOutput struct {
+	Result string `json:"result" jsonschema:"description=Result of suspending or restoring the user"`
+}
+
 // ListUsers handles the directory_users tool call
 func ListUsers(ctx context.Context, req *mcp.CallToolRequest, input ListUsersInput) (*mcp.CallToolResult, ListUsersOutput, error) {
 	client, err := utils.DefaultClient()
@@ -84,6 +129,104 @@ func CreateUser(ctx context.Context, req *mcp.CallToolRequest, input CreateUserI
 	return nil, CreateUserOutput{Result: resp}, nil
 }
 
+// GetUser handles the get_user tool call
+func GetUser(ctx context.Context, req *mcp.CallToolRequest, input GetUserInput) (*mcp.CallToolResult, GetUserOutput, error) {
+	client, err := utils.DefaultClient()
+	if err != nil {
+		return nil, GetUserOutput{}, err
+	}
+
+	user, err := client.Users.Get(input.UserKey).Do()
+	if err != nil {
+		return nil, GetUserOutput{}, fmt.Errorf("failed to get user: %w", err)
+	}
+
+	resp := fmt.Sprintf("Email: %s\nName: %s\nID: %s\nAdmin: %t\nSuspended: %t\nOrg Unit: %s\nLast Login: %s\nCreated: %s",
+		user.PrimaryEmail,
+		user.Name.FullName,
+		user.Id,
+		user.IsAdmin,
+		user.Suspended,
+		user.OrgUnitPath,
+		user.LastLoginTime,
+		user.CreationTime)
+
+	return nil, GetUserOutput{User: resp}, nil
+}
+
+// UpdateUser handles the update_user tool call
+func UpdateUser(ctx context.Context, req *mcp.CallToolRequest, input UpdateUserInput) (*mcp.CallToolResult, UpdateUserOutput, error) {
+	client, err := utils.DefaultClient()
+	if err != nil {
+		return nil, UpdateUserOutput{}, err
+	}
+
+	user := &admin.User{}
+	if input.FirstName != "" || input.LastName != "" {
+		user.Name = &admin.UserName{
+			GivenName:  input.FirstName,
+			FamilyName: input.LastName,
+		}
+	}
+	if input.Password != "" {
+		user.Password = input.Password
+	}
+	if input.OrgUnit != "" {
+		user.OrgUnitPath = input.OrgUnit
+	}
+
+	updatedUser, err := client.Users.Patch(input.UserKey, user).Do()
+	if err != nil {
+		return nil, UpdateUserOutput{}, fmt.Errorf("failed to update user: %w", err)
+	}
+
+	resp := fmt.Sprintf("User updated successfully:\nEmail: %s\nName: %s\nOrg Unit: %s",
+		updatedUser.PrimaryEmail,
+		updatedUser.Name.FullName,
+		updatedUser.OrgUnitPath)
+
+	return nil, UpdateUserOutput{Result: resp}, nil
+}
+
+// DeleteUser handles the delete_user tool call
+func DeleteUser(ctx context.Context, req *mcp.CallToolRequest, input DeleteUserInput) (*mcp.CallToolResult, DeleteUserOutput, error) {
+	client, err := utils.DefaultClient()
+	if err != nil {
+		return nil, DeleteUserOutput{}, err
+	}
+
+	if err := client.Users.Delete(input.UserKey).Do(); err != nil {
+		return nil, DeleteUserOutput{}, fmt.Errorf("failed to delete user: %w", err)
+	}
+
+	return nil, DeleteUserOutput{Result: fmt.Sprintf("User %s deleted successfully", input.UserKey)}, nil
+}
+
+// SuspendUser handles the suspend_user tool call
+func SuspendUser(ctx context.Context, req *mcp.CallToolRequest, input SuspendUserInput) (*mcp.CallToolResult, SuspendUserOutput, error) {
+	client, err := utils.DefaultClient()
+	if err != nil {
+		return nil, SuspendUserOutput{}, err
+	}
+
+	user := &admin.User{
+		Suspended:       input.Suspended,
+		ForceSendFields: []string{"Suspended"},
+	}
+
+	updatedUser, err := client.Users.Patch(input.UserKey, user).Do()
+	if err != nil {
+		return nil, SuspendUserOutput{}, fmt.Errorf("failed to update user suspension state: %w", err)
+	}
+
+	action := "restored"
+	if input.Suspended {
+		action = "suspended"
+	}
+
+	return nil, SuspendUserOutput{Result: fmt.Sprintf("User %s %s successfully", updatedUser.PrimaryEmail, action)}, nil
+}
+
 // RegisterDirectoryTools registers all directory-related tools with the MCP server
 func RegisterDirectoryTools(server *mcp.Server) {
 	mcp.AddTool(server, &mcp.Tool{
@@ -95,4 +238,24 @@ func RegisterDirectoryTools(server *mcp.Server) {
 		Name:        "create_user",
 		Description: "Create a new user in Google Workspace",
 	}, CreateUser)
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "get_user",
+		Description: "Get detailed information about a specific user",
+	}, GetUser)
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "update_user",
+		Description: "Update an existing user's name, password, or organizational unit",
+	}, UpdateUser)
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "delete_user",
+		Description: "Delete a user from Google Workspace",
+	}, DeleteUser)
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "suspend_user",
+		Description: "Suspend or restore a user account",
+	}, SuspendUser)
 }

--- a/internal/tools/drive.go
+++ b/internal/tools/drive.go
@@ -13,75 +13,75 @@ import (
 
 // ListDriveFilesInput defines input for list_drive_files tool
 type ListDriveFilesInput struct {
-	Email      string `json:"email" jsonschema:"required,description=Email address to access Drive"`
-	MaxResults int64  `json:"maxResults,omitempty" jsonschema:"description=Maximum number of files to return (default 10)"`
-	FolderID   string `json:"folderId,omitempty" jsonschema:"description=Optional folder ID to list files from"`
+	Email      string `json:"email" jsonschema:"Email address to access Drive"`
+	MaxResults int64  `json:"maxResults,omitempty" jsonschema:"Maximum number of files to return (default 10)"`
+	FolderID   string `json:"folderId,omitempty" jsonschema:"Optional folder ID to list files from"`
 }
 
 // ListDriveFilesOutput defines output for list_drive_files tool
 type ListDriveFilesOutput struct {
-	Files string `json:"files" jsonschema:"description=List of files"`
+	Files string `json:"files" jsonschema:"List of files"`
 }
 
 // SearchDriveFilesInput defines input for search_drive_files tool
 type SearchDriveFilesInput struct {
-	Email      string `json:"email" jsonschema:"required,description=Email address to access Drive"`
-	Query      string `json:"query" jsonschema:"required,description=Search query"`
-	MaxResults int64  `json:"maxResults,omitempty" jsonschema:"description=Maximum number of files to return (default 10)"`
+	Email      string `json:"email" jsonschema:"Email address to access Drive"`
+	Query      string `json:"query" jsonschema:"Search query"`
+	MaxResults int64  `json:"maxResults,omitempty" jsonschema:"Maximum number of files to return (default 10)"`
 }
 
 // SearchDriveFilesOutput defines output for search_drive_files tool
 type SearchDriveFilesOutput struct {
-	Files string `json:"files" jsonschema:"description=Search results"`
+	Files string `json:"files" jsonschema:"Search results"`
 }
 
 // GetDriveFileInput defines input for get_drive_file tool
 type GetDriveFileInput struct {
-	Email  string `json:"email" jsonschema:"required,description=Email address to access Drive"`
-	FileID string `json:"fileId" jsonschema:"required,description=File ID to retrieve"`
+	Email  string `json:"email" jsonschema:"Email address to access Drive"`
+	FileID string `json:"fileId" jsonschema:"File ID to retrieve"`
 }
 
 // GetDriveFileOutput defines output for get_drive_file tool
 type GetDriveFileOutput struct {
-	FileInfo string `json:"fileInfo" jsonschema:"description=File information"`
+	FileInfo string `json:"fileInfo" jsonschema:"File information"`
 }
 
 // CreateDriveFolderInput defines input for create_drive_folder tool
 type CreateDriveFolderInput struct {
-	Email      string `json:"email" jsonschema:"required,description=Email address to access Drive"`
-	Name       string `json:"name" jsonschema:"required,description=Folder name"`
-	ParentID   string `json:"parentId,omitempty" jsonschema:"description=Parent folder ID (optional)"`
+	Email      string `json:"email" jsonschema:"Email address to access Drive"`
+	Name       string `json:"name" jsonschema:"Folder name"`
+	ParentID   string `json:"parentId,omitempty" jsonschema:"Parent folder ID (optional)"`
 }
 
 // CreateDriveFolderOutput defines output for create_drive_folder tool
 type CreateDriveFolderOutput struct {
-	Result string `json:"result" jsonschema:"description=Created folder information"`
+	Result string `json:"result" jsonschema:"Created folder information"`
 }
 
 // UploadDriveFileInput defines input for upload_drive_file tool
 type UploadDriveFileInput struct {
-	Email      string `json:"email" jsonschema:"required,description=Email address to access Drive"`
-	FilePath   string `json:"filePath" jsonschema:"required,description=Local file path to upload"`
-	Name       string `json:"name,omitempty" jsonschema:"description=Name for the file in Drive (uses filename if not specified)"`
-	ParentID   string `json:"parentId,omitempty" jsonschema:"description=Parent folder ID (optional)"`
+	Email      string `json:"email" jsonschema:"Email address to access Drive"`
+	FilePath   string `json:"filePath" jsonschema:"Local file path to upload"`
+	Name       string `json:"name,omitempty" jsonschema:"Name for the file in Drive (uses filename if not specified)"`
+	ParentID   string `json:"parentId,omitempty" jsonschema:"Parent folder ID (optional)"`
 }
 
 // UploadDriveFileOutput defines output for upload_drive_file tool
 type UploadDriveFileOutput struct {
-	Result string `json:"result" jsonschema:"description=Uploaded file information"`
+	Result string `json:"result" jsonschema:"Uploaded file information"`
 }
 
 // ShareDriveFileInput defines input for share_drive_file tool
 type ShareDriveFileInput struct {
-	Email      string `json:"email" jsonschema:"required,description=Email address to access Drive"`
-	FileID     string `json:"fileId" jsonschema:"required,description=File ID to share"`
-	UserEmail  string `json:"userEmail" jsonschema:"required,description=Email address to share with"`
-	Role       string `json:"role,omitempty" jsonschema:"description=Permission role: reader, writer, commenter (default: reader)"`
+	Email      string `json:"email" jsonschema:"Email address to access Drive"`
+	FileID     string `json:"fileId" jsonschema:"File ID to share"`
+	UserEmail  string `json:"userEmail" jsonschema:"Email address to share with"`
+	Role       string `json:"role,omitempty" jsonschema:"Permission role: reader, writer, commenter (default: reader)"`
 }
 
 // ShareDriveFileOutput defines output for share_drive_file tool
 type ShareDriveFileOutput struct {
-	Result string `json:"result" jsonschema:"description=Share result"`
+	Result string `json:"result" jsonschema:"Share result"`
 }
 
 // ListDriveFiles handles the list_drive_files tool call

--- a/internal/tools/gmail.go
+++ b/internal/tools/gmail.go
@@ -10,12 +10,12 @@ import (
 
 // ListGmailInput defines input for list_gmail tool
 type ListGmailInput struct {
-	Email string `json:"email" jsonschema:"required,description=Email address to access Gmail"`
+	Email string `json:"email" jsonschema:"Email address to access Gmail"`
 }
 
 // ListGmailOutput defines output for list_gmail tool
 type ListGmailOutput struct {
-	Messages string `json:"messages" jsonschema:"description=List of recent messages"`
+	Messages string `json:"messages" jsonschema:"List of recent messages"`
 }
 
 // ListGmail handles the list_gmail tool call

--- a/internal/tools/groups.go
+++ b/internal/tools/groups.go
@@ -91,18 +91,19 @@ func ListGroups(ctx context.Context, req *mcp.CallToolRequest, input ListGroupsI
 		return nil, ListGroupsOutput{}, err
 	}
 
-	groups, err := client.Groups.List().Domain(input.Domain).Do()
+	var resp string
+	err = client.Groups.List().Domain(input.Domain).Pages(ctx, func(page *admin.Groups) error {
+		for _, g := range page.Groups {
+			resp += fmt.Sprintf("Email: %s Name: %s Members: %d\n", g.Email, g.Name, g.DirectMembersCount)
+		}
+		return nil
+	})
 	if err != nil {
 		return nil, ListGroupsOutput{}, fmt.Errorf("failed to list groups: %w", err)
 	}
 
-	var resp string
-	if len(groups.Groups) == 0 {
+	if resp == "" {
 		resp = "No groups found."
-	} else {
-		for _, g := range groups.Groups {
-			resp += fmt.Sprintf("Email: %s Name: %s Members: %d\n", g.Email, g.Name, g.DirectMembersCount)
-		}
 	}
 
 	return nil, ListGroupsOutput{Groups: resp}, nil
@@ -177,18 +178,19 @@ func ListGroupMembers(ctx context.Context, req *mcp.CallToolRequest, input ListG
 		return nil, ListGroupMembersOutput{}, err
 	}
 
-	members, err := client.Members.List(input.GroupKey).Do()
+	var resp string
+	err = client.Members.List(input.GroupKey).Pages(ctx, func(page *admin.Members) error {
+		for _, m := range page.Members {
+			resp += fmt.Sprintf("Email: %s Role: %s Status: %s\n", m.Email, m.Role, m.Status)
+		}
+		return nil
+	})
 	if err != nil {
 		return nil, ListGroupMembersOutput{}, fmt.Errorf("failed to list group members: %w", err)
 	}
 
-	var resp string
-	if len(members.Members) == 0 {
+	if resp == "" {
 		resp = "No members found."
-	} else {
-		for _, m := range members.Members {
-			resp += fmt.Sprintf("Email: %s Role: %s Status: %s\n", m.Email, m.Role, m.Status)
-		}
 	}
 
 	return nil, ListGroupMembersOutput{Members: resp}, nil

--- a/internal/tools/groups.go
+++ b/internal/tools/groups.go
@@ -1,0 +1,277 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"go.orx.me/mcp/google-workspace/internal/utils"
+	admin "google.golang.org/api/admin/directory/v1"
+)
+
+// ListGroupsInput defines input for list_groups tool
+type ListGroupsInput struct {
+	Domain string `json:"domain" jsonschema:"required,description=Domain to list groups from"`
+}
+
+// ListGroupsOutput defines output for list_groups tool
+type ListGroupsOutput struct {
+	Groups string `json:"groups" jsonschema:"description=List of groups with email and name"`
+}
+
+// GetGroupInput defines input for get_group tool
+type GetGroupInput struct {
+	GroupKey string `json:"groupKey" jsonschema:"required,description=Group's email address or unique group ID"`
+}
+
+// GetGroupOutput defines output for get_group tool
+type GetGroupOutput struct {
+	Group string `json:"group" jsonschema:"description=Detailed information about the group"`
+}
+
+// CreateGroupInput defines input for create_group tool
+type CreateGroupInput struct {
+	Email       string `json:"email" jsonschema:"required,description=Email address for the new group"`
+	Name        string `json:"name" jsonschema:"required,description=Display name of the group"`
+	Description string `json:"description,omitempty" jsonschema:"description=Description of the group"`
+}
+
+// CreateGroupOutput defines output for create_group tool
+type CreateGroupOutput struct {
+	Result string `json:"result" jsonschema:"description=Result of group creation"`
+}
+
+// DeleteGroupInput defines input for delete_group tool
+type DeleteGroupInput struct {
+	GroupKey string `json:"groupKey" jsonschema:"required,description=Group's email address or unique group ID"`
+}
+
+// DeleteGroupOutput defines output for delete_group tool
+type DeleteGroupOutput struct {
+	Result string `json:"result" jsonschema:"description=Result of group deletion"`
+}
+
+// ListGroupMembersInput defines input for list_group_members tool
+type ListGroupMembersInput struct {
+	GroupKey string `json:"groupKey" jsonschema:"required,description=Group's email address or unique group ID"`
+}
+
+// ListGroupMembersOutput defines output for list_group_members tool
+type ListGroupMembersOutput struct {
+	Members string `json:"members" jsonschema:"description=List of group members"`
+}
+
+// AddGroupMemberInput defines input for add_group_member tool
+type AddGroupMemberInput struct {
+	GroupKey string `json:"groupKey" jsonschema:"required,description=Group's email address or unique group ID"`
+	Email    string `json:"email" jsonschema:"required,description=Email address of the member to add"`
+	Role     string `json:"role,omitempty" jsonschema:"description=Member role: MEMBER, MANAGER, or OWNER (defaults to MEMBER)"`
+}
+
+// AddGroupMemberOutput defines output for add_group_member tool
+type AddGroupMemberOutput struct {
+	Result string `json:"result" jsonschema:"description=Result of adding the member"`
+}
+
+// RemoveGroupMemberInput defines input for remove_group_member tool
+type RemoveGroupMemberInput struct {
+	GroupKey  string `json:"groupKey" jsonschema:"required,description=Group's email address or unique group ID"`
+	MemberKey string `json:"memberKey" jsonschema:"required,description=Email address or ID of the member to remove"`
+}
+
+// RemoveGroupMemberOutput defines output for remove_group_member tool
+type RemoveGroupMemberOutput struct {
+	Result string `json:"result" jsonschema:"description=Result of removing the member"`
+}
+
+// ListGroups handles the list_groups tool call
+func ListGroups(ctx context.Context, req *mcp.CallToolRequest, input ListGroupsInput) (*mcp.CallToolResult, ListGroupsOutput, error) {
+	client, err := utils.DefaultClient()
+	if err != nil {
+		return nil, ListGroupsOutput{}, err
+	}
+
+	groups, err := client.Groups.List().Domain(input.Domain).Do()
+	if err != nil {
+		return nil, ListGroupsOutput{}, fmt.Errorf("failed to list groups: %w", err)
+	}
+
+	var resp string
+	if len(groups.Groups) == 0 {
+		resp = "No groups found."
+	} else {
+		for _, g := range groups.Groups {
+			resp += fmt.Sprintf("Email: %s Name: %s Members: %d\n", g.Email, g.Name, g.DirectMembersCount)
+		}
+	}
+
+	return nil, ListGroupsOutput{Groups: resp}, nil
+}
+
+// GetGroup handles the get_group tool call
+func GetGroup(ctx context.Context, req *mcp.CallToolRequest, input GetGroupInput) (*mcp.CallToolResult, GetGroupOutput, error) {
+	client, err := utils.DefaultClient()
+	if err != nil {
+		return nil, GetGroupOutput{}, err
+	}
+
+	group, err := client.Groups.Get(input.GroupKey).Do()
+	if err != nil {
+		return nil, GetGroupOutput{}, fmt.Errorf("failed to get group: %w", err)
+	}
+
+	resp := fmt.Sprintf("Email: %s\nName: %s\nID: %s\nDescription: %s\nDirect Members: %d",
+		group.Email,
+		group.Name,
+		group.Id,
+		group.Description,
+		group.DirectMembersCount)
+
+	return nil, GetGroupOutput{Group: resp}, nil
+}
+
+// CreateGroup handles the create_group tool call
+func CreateGroup(ctx context.Context, req *mcp.CallToolRequest, input CreateGroupInput) (*mcp.CallToolResult, CreateGroupOutput, error) {
+	client, err := utils.DefaultClient()
+	if err != nil {
+		return nil, CreateGroupOutput{}, err
+	}
+
+	group := &admin.Group{
+		Email:       input.Email,
+		Name:        input.Name,
+		Description: input.Description,
+	}
+
+	createdGroup, err := client.Groups.Insert(group).Do()
+	if err != nil {
+		return nil, CreateGroupOutput{}, fmt.Errorf("failed to create group: %w", err)
+	}
+
+	resp := fmt.Sprintf("Group created successfully:\nEmail: %s\nName: %s\nID: %s",
+		createdGroup.Email,
+		createdGroup.Name,
+		createdGroup.Id)
+
+	return nil, CreateGroupOutput{Result: resp}, nil
+}
+
+// DeleteGroup handles the delete_group tool call
+func DeleteGroup(ctx context.Context, req *mcp.CallToolRequest, input DeleteGroupInput) (*mcp.CallToolResult, DeleteGroupOutput, error) {
+	client, err := utils.DefaultClient()
+	if err != nil {
+		return nil, DeleteGroupOutput{}, err
+	}
+
+	if err := client.Groups.Delete(input.GroupKey).Do(); err != nil {
+		return nil, DeleteGroupOutput{}, fmt.Errorf("failed to delete group: %w", err)
+	}
+
+	return nil, DeleteGroupOutput{Result: fmt.Sprintf("Group %s deleted successfully", input.GroupKey)}, nil
+}
+
+// ListGroupMembers handles the list_group_members tool call
+func ListGroupMembers(ctx context.Context, req *mcp.CallToolRequest, input ListGroupMembersInput) (*mcp.CallToolResult, ListGroupMembersOutput, error) {
+	client, err := utils.DefaultClient()
+	if err != nil {
+		return nil, ListGroupMembersOutput{}, err
+	}
+
+	members, err := client.Members.List(input.GroupKey).Do()
+	if err != nil {
+		return nil, ListGroupMembersOutput{}, fmt.Errorf("failed to list group members: %w", err)
+	}
+
+	var resp string
+	if len(members.Members) == 0 {
+		resp = "No members found."
+	} else {
+		for _, m := range members.Members {
+			resp += fmt.Sprintf("Email: %s Role: %s Status: %s\n", m.Email, m.Role, m.Status)
+		}
+	}
+
+	return nil, ListGroupMembersOutput{Members: resp}, nil
+}
+
+// AddGroupMember handles the add_group_member tool call
+func AddGroupMember(ctx context.Context, req *mcp.CallToolRequest, input AddGroupMemberInput) (*mcp.CallToolResult, AddGroupMemberOutput, error) {
+	client, err := utils.DefaultClient()
+	if err != nil {
+		return nil, AddGroupMemberOutput{}, err
+	}
+
+	role := input.Role
+	if role == "" {
+		role = "MEMBER"
+	}
+
+	member := &admin.Member{
+		Email: input.Email,
+		Role:  role,
+	}
+
+	addedMember, err := client.Members.Insert(input.GroupKey, member).Do()
+	if err != nil {
+		return nil, AddGroupMemberOutput{}, fmt.Errorf("failed to add group member: %w", err)
+	}
+
+	resp := fmt.Sprintf("Member added successfully:\nGroup: %s\nEmail: %s\nRole: %s",
+		input.GroupKey,
+		addedMember.Email,
+		addedMember.Role)
+
+	return nil, AddGroupMemberOutput{Result: resp}, nil
+}
+
+// RemoveGroupMember handles the remove_group_member tool call
+func RemoveGroupMember(ctx context.Context, req *mcp.CallToolRequest, input RemoveGroupMemberInput) (*mcp.CallToolResult, RemoveGroupMemberOutput, error) {
+	client, err := utils.DefaultClient()
+	if err != nil {
+		return nil, RemoveGroupMemberOutput{}, err
+	}
+
+	if err := client.Members.Delete(input.GroupKey, input.MemberKey).Do(); err != nil {
+		return nil, RemoveGroupMemberOutput{}, fmt.Errorf("failed to remove group member: %w", err)
+	}
+
+	return nil, RemoveGroupMemberOutput{Result: fmt.Sprintf("Member %s removed from group %s successfully", input.MemberKey, input.GroupKey)}, nil
+}
+
+// RegisterGroupsTools registers all group-related tools with the MCP server
+func RegisterGroupsTools(server *mcp.Server) {
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "list_groups",
+		Description: "List groups in a domain",
+	}, ListGroups)
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "get_group",
+		Description: "Get detailed information about a specific group",
+	}, GetGroup)
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "create_group",
+		Description: "Create a new group in Google Workspace",
+	}, CreateGroup)
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "delete_group",
+		Description: "Delete a group from Google Workspace",
+	}, DeleteGroup)
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "list_group_members",
+		Description: "List members of a group",
+	}, ListGroupMembers)
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "add_group_member",
+		Description: "Add a member to a group",
+	}, AddGroupMember)
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "remove_group_member",
+		Description: "Remove a member from a group",
+	}, RemoveGroupMember)
+}

--- a/internal/tools/groups.go
+++ b/internal/tools/groups.go
@@ -11,77 +11,77 @@ import (
 
 // ListGroupsInput defines input for list_groups tool
 type ListGroupsInput struct {
-	Domain string `json:"domain" jsonschema:"required,description=Domain to list groups from"`
+	Domain string `json:"domain" jsonschema:"Domain to list groups from"`
 }
 
 // ListGroupsOutput defines output for list_groups tool
 type ListGroupsOutput struct {
-	Groups string `json:"groups" jsonschema:"description=List of groups with email and name"`
+	Groups string `json:"groups" jsonschema:"List of groups with email and name"`
 }
 
 // GetGroupInput defines input for get_group tool
 type GetGroupInput struct {
-	GroupKey string `json:"groupKey" jsonschema:"required,description=Group's email address or unique group ID"`
+	GroupKey string `json:"groupKey" jsonschema:"Group's email address or unique group ID"`
 }
 
 // GetGroupOutput defines output for get_group tool
 type GetGroupOutput struct {
-	Group string `json:"group" jsonschema:"description=Detailed information about the group"`
+	Group string `json:"group" jsonschema:"Detailed information about the group"`
 }
 
 // CreateGroupInput defines input for create_group tool
 type CreateGroupInput struct {
-	Email       string `json:"email" jsonschema:"required,description=Email address for the new group"`
-	Name        string `json:"name" jsonschema:"required,description=Display name of the group"`
-	Description string `json:"description,omitempty" jsonschema:"description=Description of the group"`
+	Email       string `json:"email" jsonschema:"Email address for the new group"`
+	Name        string `json:"name" jsonschema:"Display name of the group"`
+	Description string `json:"description,omitempty" jsonschema:"Description of the group"`
 }
 
 // CreateGroupOutput defines output for create_group tool
 type CreateGroupOutput struct {
-	Result string `json:"result" jsonschema:"description=Result of group creation"`
+	Result string `json:"result" jsonschema:"Result of group creation"`
 }
 
 // DeleteGroupInput defines input for delete_group tool
 type DeleteGroupInput struct {
-	GroupKey string `json:"groupKey" jsonschema:"required,description=Group's email address or unique group ID"`
+	GroupKey string `json:"groupKey" jsonschema:"Group's email address or unique group ID"`
 }
 
 // DeleteGroupOutput defines output for delete_group tool
 type DeleteGroupOutput struct {
-	Result string `json:"result" jsonschema:"description=Result of group deletion"`
+	Result string `json:"result" jsonschema:"Result of group deletion"`
 }
 
 // ListGroupMembersInput defines input for list_group_members tool
 type ListGroupMembersInput struct {
-	GroupKey string `json:"groupKey" jsonschema:"required,description=Group's email address or unique group ID"`
+	GroupKey string `json:"groupKey" jsonschema:"Group's email address or unique group ID"`
 }
 
 // ListGroupMembersOutput defines output for list_group_members tool
 type ListGroupMembersOutput struct {
-	Members string `json:"members" jsonschema:"description=List of group members"`
+	Members string `json:"members" jsonschema:"List of group members"`
 }
 
 // AddGroupMemberInput defines input for add_group_member tool
 type AddGroupMemberInput struct {
-	GroupKey string `json:"groupKey" jsonschema:"required,description=Group's email address or unique group ID"`
-	Email    string `json:"email" jsonschema:"required,description=Email address of the member to add"`
-	Role     string `json:"role,omitempty" jsonschema:"description=Member role: MEMBER, MANAGER, or OWNER (defaults to MEMBER)"`
+	GroupKey string `json:"groupKey" jsonschema:"Group's email address or unique group ID"`
+	Email    string `json:"email" jsonschema:"Email address of the member to add"`
+	Role     string `json:"role,omitempty" jsonschema:"Member role: MEMBER, MANAGER, or OWNER (defaults to MEMBER)"`
 }
 
 // AddGroupMemberOutput defines output for add_group_member tool
 type AddGroupMemberOutput struct {
-	Result string `json:"result" jsonschema:"description=Result of adding the member"`
+	Result string `json:"result" jsonschema:"Result of adding the member"`
 }
 
 // RemoveGroupMemberInput defines input for remove_group_member tool
 type RemoveGroupMemberInput struct {
-	GroupKey  string `json:"groupKey" jsonschema:"required,description=Group's email address or unique group ID"`
-	MemberKey string `json:"memberKey" jsonschema:"required,description=Email address or ID of the member to remove"`
+	GroupKey  string `json:"groupKey" jsonschema:"Group's email address or unique group ID"`
+	MemberKey string `json:"memberKey" jsonschema:"Email address or ID of the member to remove"`
 }
 
 // RemoveGroupMemberOutput defines output for remove_group_member tool
 type RemoveGroupMemberOutput struct {
-	Result string `json:"result" jsonschema:"description=Result of removing the member"`
+	Result string `json:"result" jsonschema:"Result of removing the member"`
 }
 
 // ListGroups handles the list_groups tool call

--- a/internal/tools/register.go
+++ b/internal/tools/register.go
@@ -7,6 +7,7 @@ import "github.com/modelcontextprotocol/go-sdk/mcp"
 // Google Workspace tools (Directory, Gmail, Calendar, Drive, Sheets).
 func RegisterAll(server *mcp.Server) {
 	RegisterDirectoryTools(server)
+	RegisterGroupsTools(server)
 	RegisterGmailTools(server)
 	RegisterCalendarTools(server)
 	RegisterDriveTools(server)

--- a/internal/tools/sheets.go
+++ b/internal/tools/sheets.go
@@ -12,75 +12,75 @@ import (
 
 // ListSpreadsheetsInput defines input for list_spreadsheets tool
 type ListSpreadsheetsInput struct {
-	Email      string `json:"email" jsonschema:"required,description=Email address to access Sheets"`
-	MaxResults int64  `json:"maxResults,omitempty" jsonschema:"description=Maximum number of spreadsheets to return (default 10)"`
+	Email      string `json:"email" jsonschema:"Email address to access Sheets"`
+	MaxResults int64  `json:"maxResults,omitempty" jsonschema:"Maximum number of spreadsheets to return (default 10)"`
 }
 
 // ListSpreadsheetsOutput defines output for list_spreadsheets tool
 type ListSpreadsheetsOutput struct {
-	Spreadsheets string `json:"spreadsheets" jsonschema:"description=List of spreadsheets"`
+	Spreadsheets string `json:"spreadsheets" jsonschema:"List of spreadsheets"`
 }
 
 // GetSpreadsheetInput defines input for get_spreadsheet tool
 type GetSpreadsheetInput struct {
-	Email         string `json:"email" jsonschema:"required,description=Email address to access Sheets"`
-	SpreadsheetID string `json:"spreadsheetId" jsonschema:"required,description=Spreadsheet ID"`
+	Email         string `json:"email" jsonschema:"Email address to access Sheets"`
+	SpreadsheetID string `json:"spreadsheetId" jsonschema:"Spreadsheet ID"`
 }
 
 // GetSpreadsheetOutput defines output for get_spreadsheet tool
 type GetSpreadsheetOutput struct {
-	Info string `json:"info" jsonschema:"description=Spreadsheet information"`
+	Info string `json:"info" jsonschema:"Spreadsheet information"`
 }
 
 // ReadSheetRangeInput defines input for read_sheet_range tool
 type ReadSheetRangeInput struct {
-	Email         string `json:"email" jsonschema:"required,description=Email address to access Sheets"`
-	SpreadsheetID string `json:"spreadsheetId" jsonschema:"required,description=Spreadsheet ID"`
-	Range         string `json:"range" jsonschema:"required,description=A1 notation range (e.g. Sheet1!A1:B10)"`
+	Email         string `json:"email" jsonschema:"Email address to access Sheets"`
+	SpreadsheetID string `json:"spreadsheetId" jsonschema:"Spreadsheet ID"`
+	Range         string `json:"range" jsonschema:"A1 notation range (e.g. Sheet1!A1:B10)"`
 }
 
 // ReadSheetRangeOutput defines output for read_sheet_range tool
 type ReadSheetRangeOutput struct {
-	Data string `json:"data" jsonschema:"description=Cell data in table format"`
+	Data string `json:"data" jsonschema:"Cell data in table format"`
 }
 
 // WriteSheetRangeInput defines input for write_sheet_range tool
 type WriteSheetRangeInput struct {
-	Email         string          `json:"email" jsonschema:"required,description=Email address to access Sheets"`
-	SpreadsheetID string          `json:"spreadsheetId" jsonschema:"required,description=Spreadsheet ID"`
-	Range         string          `json:"range" jsonschema:"required,description=A1 notation range (e.g. Sheet1!A1:B10)"`
-	Values        [][]interface{} `json:"values" jsonschema:"required,description=2D array of values to write"`
+	Email         string          `json:"email" jsonschema:"Email address to access Sheets"`
+	SpreadsheetID string          `json:"spreadsheetId" jsonschema:"Spreadsheet ID"`
+	Range         string          `json:"range" jsonschema:"A1 notation range (e.g. Sheet1!A1:B10)"`
+	Values        [][]interface{} `json:"values" jsonschema:"2D array of values to write"`
 }
 
 // WriteSheetRangeOutput defines output for write_sheet_range tool
 type WriteSheetRangeOutput struct {
-	Result string `json:"result" jsonschema:"description=Write operation result"`
+	Result string `json:"result" jsonschema:"Write operation result"`
 }
 
 
 // AppendSheetRowsInput defines input for append_sheet_rows tool
 type AppendSheetRowsInput struct {
-	Email         string          `json:"email" jsonschema:"required,description=Email address to access Sheets"`
-	SpreadsheetID string          `json:"spreadsheetId" jsonschema:"required,description=Spreadsheet ID"`
-	Range         string          `json:"range" jsonschema:"required,description=A1 notation range to append after (e.g. Sheet1!A:A)"`
-	Values        [][]interface{} `json:"values" jsonschema:"required,description=2D array of rows to append"`
+	Email         string          `json:"email" jsonschema:"Email address to access Sheets"`
+	SpreadsheetID string          `json:"spreadsheetId" jsonschema:"Spreadsheet ID"`
+	Range         string          `json:"range" jsonschema:"A1 notation range to append after (e.g. Sheet1!A:A)"`
+	Values        [][]interface{} `json:"values" jsonschema:"2D array of rows to append"`
 }
 
 // AppendSheetRowsOutput defines output for append_sheet_rows tool
 type AppendSheetRowsOutput struct {
-	Result string `json:"result" jsonschema:"description=Append operation result"`
+	Result string `json:"result" jsonschema:"Append operation result"`
 }
 
 // CreateSpreadsheetInput defines input for create_spreadsheet tool
 type CreateSpreadsheetInput struct {
-	Email      string   `json:"email" jsonschema:"required,description=Email address to access Sheets"`
-	Title      string   `json:"title" jsonschema:"required,description=Spreadsheet title"`
-	SheetNames []string `json:"sheetNames,omitempty" jsonschema:"description=Optional list of sheet names to create"`
+	Email      string   `json:"email" jsonschema:"Email address to access Sheets"`
+	Title      string   `json:"title" jsonschema:"Spreadsheet title"`
+	SheetNames []string `json:"sheetNames,omitempty" jsonschema:"Optional list of sheet names to create"`
 }
 
 // CreateSpreadsheetOutput defines output for create_spreadsheet tool
 type CreateSpreadsheetOutput struct {
-	Result string `json:"result" jsonschema:"description=Created spreadsheet information"`
+	Result string `json:"result" jsonschema:"Created spreadsheet information"`
 }
 
 // ListSpreadsheets handles the list_spreadsheets tool call

--- a/internal/tools/sheets_test.go
+++ b/internal/tools/sheets_test.go
@@ -47,10 +47,6 @@ func TestSheetsInputStructTagCompleteness(t *testing.T) {
 					t.Errorf("Field %s.%s is missing jsonschema tag", structName, fieldName)
 				}
 
-				// Check jsonschema tag has description
-				if jsonschemaTag != "" && !strings.Contains(jsonschemaTag, "description=") {
-					t.Errorf("Field %s.%s jsonschema tag is missing description", structName, fieldName)
-				}
 			}
 		})
 	}
@@ -96,9 +92,9 @@ func TestSheetsRequiredFieldsHaveRequiredTag(t *testing.T) {
 					continue
 				}
 
-				jsonschemaTag := field.Tag.Get("jsonschema")
-				if !strings.Contains(jsonschemaTag, "required") {
-					t.Errorf("Field %s.%s should have 'required' in jsonschema tag", structName, fieldName)
+				jsonTag := field.Tag.Get("json")
+				if strings.Contains(jsonTag, "omitempty") || strings.Contains(jsonTag, "omitzero") {
+					t.Errorf("Required field %s.%s should not be omitempty in json tag", structName, fieldName)
 				}
 			}
 		})
@@ -135,9 +131,9 @@ func TestSheetsOptionalFieldsNotRequired(t *testing.T) {
 					continue
 				}
 
-				jsonschemaTag := field.Tag.Get("jsonschema")
-				if strings.Contains(jsonschemaTag, "required") {
-					t.Errorf("Field %s.%s should NOT have 'required' in jsonschema tag (it's optional)", structName, fieldName)
+				jsonTag := field.Tag.Get("json")
+				if !strings.Contains(jsonTag, "omitempty") && !strings.Contains(jsonTag, "omitzero") {
+					t.Errorf("Optional field %s.%s should be omitempty in json tag", structName, fieldName)
 				}
 			}
 		})
@@ -660,10 +656,10 @@ func TestProperty6_ValuesFieldType(t *testing.T) {
 			t.Fatalf("Values field type should be %s, got %s", expectedType, field.Type.String())
 		}
 
-		// Property: Field must have required tag
-		jsonschemaTag := field.Tag.Get("jsonschema")
-		if !strings.Contains(jsonschemaTag, "required") {
-			t.Fatal("Values field should have 'required' in jsonschema tag")
+		// Property: Field must be required (no omitempty in json tag)
+		jsonTag := field.Tag.Get("json")
+		if strings.Contains(jsonTag, "omitempty") || strings.Contains(jsonTag, "omitzero") {
+			t.Fatal("Values field should not be omitempty in json tag")
 		}
 	})
 }

--- a/internal/tools/tasks.go
+++ b/internal/tools/tasks.go
@@ -11,78 +11,78 @@ import (
 
 // ListTaskListsInput defines input for list_task_lists tool
 type ListTaskListsInput struct {
-	Email string `json:"email" jsonschema:"required,description=Email address to access Google Tasks"`
+	Email string `json:"email" jsonschema:"Email address to access Google Tasks"`
 }
 
 // ListTaskListsOutput defines output for list_task_lists tool
 type ListTaskListsOutput struct {
-	TaskLists string `json:"taskLists" jsonschema:"description=List of task lists"`
+	TaskLists string `json:"taskLists" jsonschema:"List of task lists"`
 }
 
 // ListTasksInput defines input for list_tasks tool
 type ListTasksInput struct {
-	Email      string `json:"email" jsonschema:"required,description=Email address to access Google Tasks"`
-	TaskListID string `json:"taskListId" jsonschema:"required,description=Task list identifier (use @default for the default task list)"`
+	Email      string `json:"email" jsonschema:"Email address to access Google Tasks"`
+	TaskListID string `json:"taskListId" jsonschema:"Task list identifier (use @default for the default task list)"`
 }
 
 // ListTasksOutput defines output for list_tasks tool
 type ListTasksOutput struct {
-	Tasks string `json:"tasks" jsonschema:"description=List of tasks"`
+	Tasks string `json:"tasks" jsonschema:"List of tasks"`
 }
 
 // CreateTaskInput defines input for create_task tool
 type CreateTaskInput struct {
-	Email      string `json:"email" jsonschema:"required,description=Email address to access Google Tasks"`
-	TaskListID string `json:"taskListId" jsonschema:"required,description=Task list identifier (use @default for the default task list)"`
-	Title      string `json:"title" jsonschema:"required,description=Title of the task"`
-	Notes      string `json:"notes,omitempty" jsonschema:"description=Notes describing the task"`
-	Due        string `json:"due,omitempty" jsonschema:"description=Due date in RFC3339 format (e.g. 2024-12-31T00:00:00Z)"`
+	Email      string `json:"email" jsonschema:"Email address to access Google Tasks"`
+	TaskListID string `json:"taskListId" jsonschema:"Task list identifier (use @default for the default task list)"`
+	Title      string `json:"title" jsonschema:"Title of the task"`
+	Notes      string `json:"notes,omitempty" jsonschema:"Notes describing the task"`
+	Due        string `json:"due,omitempty" jsonschema:"Due date in RFC3339 format (e.g. 2024-12-31T00:00:00Z)"`
 }
 
 // CreateTaskOutput defines output for create_task tool
 type CreateTaskOutput struct {
-	Result string `json:"result" jsonschema:"description=Result of task creation"`
+	Result string `json:"result" jsonschema:"Result of task creation"`
 }
 
 
 // UpdateTaskInput defines input for update_task tool
 type UpdateTaskInput struct {
-	Email      string `json:"email" jsonschema:"required,description=Email address to access Google Tasks"`
-	TaskListID string `json:"taskListId" jsonschema:"required,description=Task list identifier"`
-	TaskID     string `json:"taskId" jsonschema:"required,description=Task identifier"`
-	Title      string `json:"title,omitempty" jsonschema:"description=New title of the task"`
-	Notes      string `json:"notes,omitempty" jsonschema:"description=New notes for the task"`
-	Status     string `json:"status,omitempty" jsonschema:"description=Task status: needsAction or completed"`
-	Due        string `json:"due,omitempty" jsonschema:"description=Due date in RFC3339 format"`
+	Email      string `json:"email" jsonschema:"Email address to access Google Tasks"`
+	TaskListID string `json:"taskListId" jsonschema:"Task list identifier"`
+	TaskID     string `json:"taskId" jsonschema:"Task identifier"`
+	Title      string `json:"title,omitempty" jsonschema:"New title of the task"`
+	Notes      string `json:"notes,omitempty" jsonschema:"New notes for the task"`
+	Status     string `json:"status,omitempty" jsonschema:"Task status: needsAction or completed"`
+	Due        string `json:"due,omitempty" jsonschema:"Due date in RFC3339 format"`
 }
 
 // UpdateTaskOutput defines output for update_task tool
 type UpdateTaskOutput struct {
-	Result string `json:"result" jsonschema:"description=Result of task update"`
+	Result string `json:"result" jsonschema:"Result of task update"`
 }
 
 // DeleteTaskInput defines input for delete_task tool
 type DeleteTaskInput struct {
-	Email      string `json:"email" jsonschema:"required,description=Email address to access Google Tasks"`
-	TaskListID string `json:"taskListId" jsonschema:"required,description=Task list identifier"`
-	TaskID     string `json:"taskId" jsonschema:"required,description=Task identifier"`
+	Email      string `json:"email" jsonschema:"Email address to access Google Tasks"`
+	TaskListID string `json:"taskListId" jsonschema:"Task list identifier"`
+	TaskID     string `json:"taskId" jsonschema:"Task identifier"`
 }
 
 // DeleteTaskOutput defines output for delete_task tool
 type DeleteTaskOutput struct {
-	Result string `json:"result" jsonschema:"description=Result of task deletion"`
+	Result string `json:"result" jsonschema:"Result of task deletion"`
 }
 
 // CompleteTaskInput defines input for complete_task tool
 type CompleteTaskInput struct {
-	Email      string `json:"email" jsonschema:"required,description=Email address to access Google Tasks"`
-	TaskListID string `json:"taskListId" jsonschema:"required,description=Task list identifier"`
-	TaskID     string `json:"taskId" jsonschema:"required,description=Task identifier"`
+	Email      string `json:"email" jsonschema:"Email address to access Google Tasks"`
+	TaskListID string `json:"taskListId" jsonschema:"Task list identifier"`
+	TaskID     string `json:"taskId" jsonschema:"Task identifier"`
 }
 
 // CompleteTaskOutput defines output for complete_task tool
 type CompleteTaskOutput struct {
-	Result string `json:"result" jsonschema:"description=Result of marking task as completed"`
+	Result string `json:"result" jsonschema:"Result of marking task as completed"`
 }
 
 // ListTaskLists handles the list_task_lists tool call

--- a/internal/tools/tasks_test.go
+++ b/internal/tools/tasks_test.go
@@ -45,10 +45,6 @@ func TestTasksInputStructTagCompleteness(t *testing.T) {
 					t.Errorf("Field %s.%s is missing jsonschema tag", structName, fieldName)
 				}
 
-				// Check jsonschema tag has description
-				if jsonschemaTag != "" && !strings.Contains(jsonschemaTag, "description=") {
-					t.Errorf("Field %s.%s jsonschema tag is missing description", structName, fieldName)
-				}
 			}
 		})
 	}
@@ -93,9 +89,9 @@ func TestTasksRequiredFieldsHaveRequiredTag(t *testing.T) {
 					continue
 				}
 
-				jsonschemaTag := field.Tag.Get("jsonschema")
-				if !strings.Contains(jsonschemaTag, "required") {
-					t.Errorf("Field %s.%s should have 'required' in jsonschema tag", structName, fieldName)
+				jsonTag := field.Tag.Get("json")
+				if strings.Contains(jsonTag, "omitempty") || strings.Contains(jsonTag, "omitzero") {
+					t.Errorf("Required field %s.%s should not be omitempty in json tag", structName, fieldName)
 				}
 			}
 		})
@@ -132,9 +128,9 @@ func TestTasksOptionalFieldsNotRequired(t *testing.T) {
 					continue
 				}
 
-				jsonschemaTag := field.Tag.Get("jsonschema")
-				if strings.Contains(jsonschemaTag, "required") {
-					t.Errorf("Field %s.%s should NOT have 'required' in jsonschema tag (it's optional)", structName, fieldName)
+				jsonTag := field.Tag.Get("json")
+				if !strings.Contains(jsonTag, "omitempty") && !strings.Contains(jsonTag, "omitzero") {
+					t.Errorf("Optional field %s.%s should be omitempty in json tag", structName, fieldName)
 				}
 			}
 		})

--- a/internal/tools/tools_test.go
+++ b/internal/tools/tools_test.go
@@ -52,15 +52,12 @@ func TestInputStructTagCompleteness(t *testing.T) {
 					t.Errorf("Field %s.%s is missing json tag", structName, fieldName)
 				}
 
-				// Check jsonschema tag exists
+				// Check jsonschema tag exists. With jsonschema-go, the entire
+				// tag value is the field description, so a non-empty tag is all
+				// that's required.
 				jsonschemaTag := field.Tag.Get("jsonschema")
 				if jsonschemaTag == "" {
 					t.Errorf("Field %s.%s is missing jsonschema tag", structName, fieldName)
-				}
-
-				// Check jsonschema tag has description
-				if jsonschemaTag != "" && !strings.Contains(jsonschemaTag, "description=") {
-					t.Errorf("Field %s.%s jsonschema tag is missing description", structName, fieldName)
 				}
 			}
 		})
@@ -88,7 +85,9 @@ func TestOutputStructTagCompleteness(t *testing.T) {
 	}
 }
 
-// TestRequiredFieldsHaveRequiredTag verifies that required Input fields have the required jsonschema tag
+// TestRequiredFieldsHaveRequiredTag verifies that required Input fields are not
+// marked omitempty in their json tag. With jsonschema-go, a field is required
+// unless its json tag carries omitempty/omitzero.
 func TestRequiredFieldsHaveRequiredTag(t *testing.T) {
 	// Map of struct name to required field names based on requirements
 	requiredFields := map[string][]string{
@@ -117,16 +116,17 @@ func TestRequiredFieldsHaveRequiredTag(t *testing.T) {
 					continue
 				}
 
-				jsonschemaTag := field.Tag.Get("jsonschema")
-				if !strings.Contains(jsonschemaTag, "required") {
-					t.Errorf("Field %s.%s should have 'required' in jsonschema tag", structName, fieldName)
+				jsonTag := field.Tag.Get("json")
+				if strings.Contains(jsonTag, "omitempty") || strings.Contains(jsonTag, "omitzero") {
+					t.Errorf("Required field %s.%s should not be omitempty in json tag", structName, fieldName)
 				}
 			}
 		})
 	}
 }
 
-// TestOptionalFieldsNotRequired verifies that optional fields don't have required tag
+// TestOptionalFieldsNotRequired verifies that optional fields carry omitempty in
+// their json tag, which is what marks them optional for jsonschema-go.
 func TestOptionalFieldsNotRequired(t *testing.T) {
 	// Map of struct name to optional field names
 	optionalFields := map[string][]string{
@@ -151,9 +151,9 @@ func TestOptionalFieldsNotRequired(t *testing.T) {
 					continue
 				}
 
-				jsonschemaTag := field.Tag.Get("jsonschema")
-				if strings.Contains(jsonschemaTag, "required") {
-					t.Errorf("Field %s.%s should NOT have 'required' in jsonschema tag (it's optional)", structName, fieldName)
+				jsonTag := field.Tag.Get("json")
+				if !strings.Contains(jsonTag, "omitempty") && !strings.Contains(jsonTag, "omitzero") {
+					t.Errorf("Optional field %s.%s should be omitempty in json tag", structName, fieldName)
 				}
 			}
 		})

--- a/internal/tools/tools_test.go
+++ b/internal/tools/tools_test.go
@@ -18,6 +18,17 @@ func allInputStructs() []interface{} {
 	return []interface{}{
 		ListUsersInput{},
 		CreateUserInput{},
+		GetUserInput{},
+		UpdateUserInput{},
+		DeleteUserInput{},
+		SuspendUserInput{},
+		ListGroupsInput{},
+		GetGroupInput{},
+		CreateGroupInput{},
+		DeleteGroupInput{},
+		ListGroupMembersInput{},
+		AddGroupMemberInput{},
+		RemoveGroupMemberInput{},
 		ListGmailInput{},
 		ListCalendarEventsInput{},
 		CreateCalendarEventInput{},
@@ -29,6 +40,17 @@ func allOutputStructs() []interface{} {
 	return []interface{}{
 		ListUsersOutput{},
 		CreateUserOutput{},
+		GetUserOutput{},
+		UpdateUserOutput{},
+		DeleteUserOutput{},
+		SuspendUserOutput{},
+		ListGroupsOutput{},
+		GetGroupOutput{},
+		CreateGroupOutput{},
+		DeleteGroupOutput{},
+		ListGroupMembersOutput{},
+		AddGroupMemberOutput{},
+		RemoveGroupMemberOutput{},
 		ListGmailOutput{},
 		ListCalendarEventsOutput{},
 		CreateCalendarEventOutput{},
@@ -91,11 +113,22 @@ func TestOutputStructTagCompleteness(t *testing.T) {
 func TestRequiredFieldsHaveRequiredTag(t *testing.T) {
 	// Map of struct name to required field names based on requirements
 	requiredFields := map[string][]string{
-		"ListUsersInput":            {"Domain"},
-		"CreateUserInput":           {"Email", "FirstName", "LastName", "Password"},
-		"ListGmailInput":            {"Email"},
-		"ListCalendarEventsInput":   {"Email"},
-		"CreateCalendarEventInput":  {"Email", "Summary", "StartTime", "EndTime"},
+		"ListUsersInput":           {"Domain"},
+		"CreateUserInput":          {"Email", "FirstName", "LastName", "Password"},
+		"GetUserInput":             {"UserKey"},
+		"UpdateUserInput":          {"UserKey"},
+		"DeleteUserInput":          {"UserKey"},
+		"SuspendUserInput":         {"UserKey", "Suspended"},
+		"ListGroupsInput":          {"Domain"},
+		"GetGroupInput":            {"GroupKey"},
+		"CreateGroupInput":         {"Email", "Name"},
+		"DeleteGroupInput":         {"GroupKey"},
+		"ListGroupMembersInput":    {"GroupKey"},
+		"AddGroupMemberInput":      {"GroupKey", "Email"},
+		"RemoveGroupMemberInput":   {"GroupKey", "MemberKey"},
+		"ListGmailInput":           {"Email"},
+		"ListCalendarEventsInput":  {"Email"},
+		"CreateCalendarEventInput": {"Email", "Summary", "StartTime", "EndTime"},
 	}
 
 	for _, input := range allInputStructs() {
@@ -130,6 +163,9 @@ func TestRequiredFieldsHaveRequiredTag(t *testing.T) {
 func TestOptionalFieldsNotRequired(t *testing.T) {
 	// Map of struct name to optional field names
 	optionalFields := map[string][]string{
+		"UpdateUserInput":          {"FirstName", "LastName", "Password", "OrgUnit"},
+		"CreateGroupInput":         {"Description"},
+		"AddGroupMemberInput":      {"Role"},
 		"CreateCalendarEventInput": {"Description"},
 	}
 

--- a/internal/utils/client.go
+++ b/internal/utils/client.go
@@ -84,7 +84,11 @@ func tokenSource(sa []byte, adminEmail string, scopes ...string) (oauth2.TokenSo
 }
 
 func newClient(sa []byte, adminEmail string) (*admin.Service, error) {
-	ts, err := tokenSource(sa, adminEmail, admin.AdminDirectoryUserScope)
+	ts, err := tokenSource(sa, adminEmail,
+		admin.AdminDirectoryUserScope,
+		admin.AdminDirectoryGroupScope,
+		admin.AdminDirectoryGroupMemberScope,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/utils/client.go
+++ b/internal/utils/client.go
@@ -166,7 +166,6 @@ func newSheetsClient(sa []byte, email string) (*sheets.Service, error) {
 	return srv, nil
 }
 
-
 func NewTasksClient(email string) (*tasks.Service, error) {
 	sa, err := defaultServiceAccount()
 	if err != nil {


### PR DESCRIPTION
Add get_user, update_user, delete_user, suspend_user for full user lifecycle management, plus groups.go with list/get/create/delete group and add/remove/list member tools. Extend the admin client with group and group-member scopes.